### PR TITLE
`ST10Controller`: Add missing stop notification request for moves

### DIFF
--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -301,7 +301,7 @@ class ST10Controller(
         self._init_error_timer.start()
 
         # Receive a notification when motor has finished moving
-        self._send_string(_SEND_STRING_MAGIC)
+        self._notify_on_stopped()
 
     def _relative_move(self, steps: int) -> None:
         """Move the stepper motor to the specified relative position.
@@ -367,6 +367,7 @@ class ST10Controller(
         """
         # "Feed to position"
         self._write_check(f"FP{step}")
+        self._notify_on_stopped()
 
     def _send_string(self, string: str) -> None:
         """Request that the device sends string when operations have completed.
@@ -476,3 +477,7 @@ class ST10Controller(
     def stop_moving(self) -> None:
         """Immediately stop moving the motor."""
         self._write_check("ST")
+
+    def _notify_on_stopped(self) -> None:
+        """Wait until the motor has stopped moving and send a message when done."""
+        self._send_string(_SEND_STRING_MAGIC)

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -377,8 +377,10 @@ def test_get_step(
 def test_set_step(dev: ST10Controller, step: int) -> None:
     """Test setting the step property."""
     with patch.object(dev, "_write_check") as write_mock:
-        dev.step = step
-        write_mock.assert_called_once_with(f"FP{step}")
+        with patch.object(dev, "_notify_on_stopped") as notify_mock:
+            dev.step = step
+            write_mock.assert_called_once_with(f"FP{step}")
+            notify_mock.assert_called_once_with()
 
 
 @pytest.mark.parametrize("string", ("a", "A", "Z", "hello"))


### PR DESCRIPTION
# Description

It seems like we accidentally broke the `ST10Controller` so that we no longer get a notification when the motor has finished moving. Oops.

It can be fixed by sending the (weirdly named) "send string" command immediately after the move command.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
