### PR TITLE
Check stepper alarm status after move

### DIFF
--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -254,10 +254,20 @@ class ST10Controller(
 
         # For future move end messages, use a different handler
         self._reader.async_read_completed.disconnect(self._on_initial_move_end)
-        self._reader.async_read_completed.connect(self.send_move_end_message)
+        self._reader.async_read_completed.connect(self._on_move_end)
 
         # Signal that this device is ready to be used
         self.signal_is_opened()
+
+    def _on_move_end(self) -> None:
+        """Signal whether move was successful or an error occurred."""
+        if alarm_code := self.alarm_code:
+            # A controller error occurred
+            self.send_error_message(ST10ControllerError(str(alarm_code)))
+            return
+
+        # Move was successful
+        self.send_move_end_message()
 
     def _check_device_id(self) -> None:
         """Check that the ID is the correct one for an ST10.

--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -526,6 +526,9 @@ class ST10Controller(
             SerialTimeoutException: Timed out waiting for response from device
             ST10ControllerError: Malformed message received from device
             UnicodeEncodeError: Message to be sent is malformed
+
+        Returns:
+            int: The integer corresponding to the named value
         """
         resp = self._request_value(name)
         try:

--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -264,10 +264,9 @@ class ST10Controller(
         if alarm_code := self.alarm_code:
             # A controller error occurred
             self.send_error_message(ST10ControllerError(str(alarm_code)))
-            return
-
-        # Move was successful
-        self.send_move_end_message()
+        else:
+            # Move was successful
+            self.send_move_end_message()
 
     def _check_device_id(self) -> None:
         """Check that the ID is the correct one for an ST10.

--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -323,8 +323,7 @@ class ST10Controller(
 
         For a complete list of status codes and their meanings, consult the manual.
         """
-        # SC is formatted as a hexadecimal string
-        return int(self._request_value("SC"), 16)
+        return self._request_int("SC", 16)
 
     @property
     def is_moving(self) -> bool:
@@ -347,11 +346,7 @@ class ST10Controller(
             SerialTimeoutException: Timed out waiting for response from device
             ST10ControllerError: Malformed message received from device
         """
-        step = self._request_value("IP")
-        try:
-            return int(step)
-        except ValueError:
-            raise ST10ControllerError(f"Invalid value for step received: {step}")
+        return self._request_int("IP")
 
     @step.setter
     def step(self, step: int) -> None:
@@ -473,6 +468,25 @@ class ST10Controller(
             raise ST10ControllerError(f"Unexpected response when querying value {name}")
 
         return response[len(name) + 1 :]
+
+    def _request_int(self, name: str, base: int = 10) -> int:
+        """Request a named value from the device and interpret the result as an int.
+
+        Args:
+            name: Variable name
+            base: Base of integer (e.g. 16 for hexadecimal)
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+            UnicodeEncodeError: Message to be sent is malformed
+        """
+        resp = self._request_value(name)
+        try:
+            return int(resp, base)
+        except ValueError:
+            raise ST10ControllerError(f"Non-integer response received ({resp})")
 
     def stop_moving(self) -> None:
         """Immediately stop moving the motor."""

--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -8,6 +8,7 @@ The specification is available online:
 """
 
 import logging
+from enum import IntFlag
 from queue import Queue
 
 from PySide6.QtCore import QThread, QTimer, Signal
@@ -20,6 +21,34 @@ from frog.hardware.serial_device import SerialDevice
 
 class ST10ControllerError(SerialException):
     """Indicates that an error has occurred with the ST10 controller."""
+
+
+class ST10AlarmCode(IntFlag):
+    """The set of possible alarm codes for the ST10 motor controller.
+
+    These values are taken from the manual. Note that the alarm code is a bit mask, so
+    several of these may be set at once (if you're especially unlucky!).
+    """
+
+    POSITION_LIMIT = 0x0001
+    CCW_LIMIT = 0x0002
+    CW_LIMIT = 0x0004
+    OVER_TEMP = 0x0008
+    INTERNAL_VOLTAGE = 0x0010
+    OVER_VOLTAGE = 0x0020
+    UNDER_VOLTAGE = 0x0040
+    OVER_CURRENT = 0x0080
+    OPEN_MOTOR_WINDING = 0x0100
+    BAD_ENCODER = 0x0200
+    COMM_ERROR = 0x0400
+    BAD_FLASH = 0x0800
+    NO_MOVE = 0x1000
+    BLANK_Q_SEGMENT = 0x4000
+
+    def __str__(self) -> str:
+        """Convert the set alarm code bits to a string."""
+        error_str = ", ".join(code.name for code in self)  # type: ignore[misc]
+        return f"Alarm code 0x{self:04X}: {error_str}"
 
 
 _SEND_STRING_MAGIC = "Z"
@@ -332,6 +361,12 @@ class ST10Controller(
         This is done by checking whether the status code has the moving bit set.
         """
         return self.status_code & 0x0010 == 0x0010
+
+    @property
+    def alarm_code(self) -> ST10AlarmCode | None:
+        """Get the current alarm code for the controller, if any."""
+        code = self._request_int("AL", 16)
+        return ST10AlarmCode(code) if code else None
 
     @property
     def step(self) -> int:

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -131,7 +131,7 @@ def test_on_initial_move_end(dev: ST10Controller) -> None:
                     dev._on_initial_move_end
                 )
                 reader_mock.async_read_completed.connect.assert_called_once_with(
-                    dev.send_move_end_message
+                    dev._on_move_end
                 )
                 timer_mock.stop.assert_called_once_with()
                 signal_mock.assert_called_once_with()

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -138,6 +138,38 @@ def test_on_initial_move_end(dev: ST10Controller) -> None:
 
 
 @patch(
+    "frog.hardware.plugins.stepper_motor.st10_controller.ST10Controller.alarm_code",
+    new_callable=PropertyMock,
+    return_value=None,
+)
+def test_on_move_end_success(alarm_mock: Mock, dev: ST10Controller) -> None:
+    """Test the _on_move_end() method when no error has occurred."""
+    with (
+        patch.object(dev, "send_move_end_message") as success_mock,
+        patch.object(dev, "send_error_message") as fail_mock,
+    ):
+        dev._on_move_end()
+        success_mock.assert_called_once_with()
+        fail_mock.assert_not_called()
+
+
+@patch(
+    "frog.hardware.plugins.stepper_motor.st10_controller.ST10Controller.alarm_code",
+    new_callable=PropertyMock,
+    return_value=ST10AlarmCode.CW_LIMIT,
+)
+def test_on_move_end_fail(alarm_mock: Mock, dev: ST10Controller) -> None:
+    """Test the _on_move_end() method when an error has occurred."""
+    with (
+        patch.object(dev, "send_move_end_message") as success_mock,
+        patch.object(dev, "send_error_message") as fail_mock,
+    ):
+        dev._on_move_end()
+        success_mock.assert_not_called()
+        fail_mock.assert_called_once()
+
+
+@patch(
     "frog.hardware.plugins.stepper_motor.st10_controller.ST10Controller.angle",
     new_callable=PropertyMock,
 )

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -9,6 +9,7 @@ import pytest
 from serial import SerialException, SerialTimeoutException
 
 from frog.hardware.plugins.stepper_motor.st10_controller import (
+    ST10AlarmCode,
     ST10Controller,
     ST10ControllerError,
     _SerialReader,
@@ -352,6 +353,27 @@ def test_is_moving(
     status_code_mock.return_value = status
     expected = status & 0x0010 != 0  # check moving bit is set
     assert dev.is_moving == expected
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    (
+        (0, None),
+        (0x0004, ST10AlarmCode.CW_LIMIT),
+        (0x0014, ST10AlarmCode.INTERNAL_VOLTAGE | ST10AlarmCode.CW_LIMIT),
+    ),
+)
+def test_alarm_code(
+    code: int,
+    expected: ST10AlarmCode | None,
+    dev: ST10Controller,
+) -> None:
+    """Test the alarm_code property."""
+    with patch.object(dev, "_request_int") as request_mock:
+        request_mock.return_value = code
+        ret = dev.alarm_code
+        request_mock.assert_called_once_with("AL", 16)
+        assert ret == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -257,6 +257,36 @@ def test_request_value(
             write_mock.assert_called_once_with(name)
 
 
+@pytest.mark.parametrize(
+    "response,base,expected",
+    (("10", None, 10), ("10", 10, 10), ("9", 10, 9), ("10", 16, 16), ("F", 16, 15)),
+)
+def test_request_int(
+    response: str, base: int | None, expected: int, dev: ST10Controller
+) -> None:
+    """Test the _request_int() method."""
+    with patch.object(dev, "_request_value") as request_mock:
+        request_mock.return_value = response
+
+        # This is so we can test that the default base is 10
+        kwargs = {}
+        if base:
+            kwargs["base"] = base
+
+        ret = dev._request_int("SOME_NAME", **kwargs)
+        assert ret == expected
+        request_mock.assert_called_once_with("SOME_NAME")
+
+
+def test_request_int_bad(dev: ST10Controller) -> None:
+    """Test the _request_int() method raises an error for non-integer return values."""
+    with (
+        patch.object(dev, "_request_value", return_value="a string"),
+        pytest.raises(ST10ControllerError),
+    ):
+        dev._request_int("SOME_NAME")
+
+
 def test_check_device_id(dev: ST10Controller) -> None:
     """Test the _check_device_id() method."""
     # Check with the correct ID


### PR DESCRIPTION
# Description

The ST10 controller has an "alarm status" that can be queried to find out if an error has occurred. This includes drive faults, low voltage etc. as well as if the motor has hit a limit switch (which was the original motivation for looking at this -- currently we just hardcode the position of the limits in FROG so we don't hit them). Jon has said that he might not put limit switches on the new UNIRAS rig, in which case we could just turn them off, but in any case it seems useful to know whether something's gone wrong with the motor, especially if you're 10,000 ft up.

When an error occurs, we should get a notification because the motor will stop so it makes sense to query the motor at this point.

Closes #703.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [xgg] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
