### PR TITLE
`ST10Controller`: Disable limit switches

### DIFF
--- a/frog/gui/stepper_motor_view.py
+++ b/frog/gui/stepper_motor_view.py
@@ -81,7 +81,7 @@ class StepperMotorControl(DevicePanel):
 
         If angle corresponds to a preset, show the associated name as well as the value.
         """
-        text = f"{moved_to}°"
+        text = f"{round(moved_to)}°"
         if preset := next((k for k, v in ANGLE_PRESETS.items() if v == moved_to), None):
             text += f" ({preset})"
         self.mirror_position_display.setText(text)

--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -219,6 +219,8 @@ class ST10Controller(
         # Check that we are connecting to an ST10
         self._check_device_id()
 
+        self._disable_limit_switches()
+
         # Move mirror to home position
         self._home_and_reset()
 
@@ -280,6 +282,18 @@ class ST10Controller(
         self._write("MV")
         if self._read_sync() != self.ST10_MODEL_ID:
             raise ST10ControllerError("Device ID indicates this is not an ST10")
+
+    def _disable_limit_switches(self) -> None:
+        """Disable the limit switches on the controller.
+
+        Without this, we get an error if the motor hits a limit switch. The limit
+        switches aren't actually needed to protect anything in either the FINESSE or
+        UNIRAS rigs (the worst that will happen is the motor will just spin around), so
+        we don't need them.
+        """
+        # "Define limit". This command allows for setting the behaviour of the limit
+        # switches. The "3" option means that they are treated as normal inputs.
+        self._write_check("DL3")
 
     def _get_input_status(self, input: int) -> bool:
         """Read the status of the device's inputs.

--- a/frog/hardware/plugins/stepper_motor/stepper_motor_base.py
+++ b/frog/hardware/plugins/stepper_motor/stepper_motor_base.py
@@ -80,8 +80,8 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
         if isinstance(target, str):
             target = self.preset_angle(target)
 
-        if target < 0.0 or target > 270.0:
-            raise ValueError("Angle must be between 0° and 270°")
+        if target < 0.0 or target >= 360.0:
+            raise ValueError("Angle must be between 0° and 360°")
 
         self.step = round(self.steps_per_rotation * target / 360.0)
 

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -83,7 +83,7 @@ def test_update_mirror_position_display(qtbot: QtBot) -> None:
     control = StepperMotorControl()
 
     control._update_mirror_position_display(moved_to=ANGLE_PRESETS["zenith"])
-    assert control.mirror_position_display.text() == "180.0\u00b0 (zenith)"
+    assert control.mirror_position_display.text() == "180\u00b0 (zenith)"
 
     control._update_mirror_position_display(moved_to=12.34)
-    assert control.mirror_position_display.text() == "12.34\u00b0"
+    assert control.mirror_position_display.text() == "12\u00b0"

--- a/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
+++ b/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
@@ -48,7 +48,7 @@ def test_init_raises(steps: int, raises: Any, subscribe_mock: MagicMock, qtbot) 
         [
             target,
             pytest.raises(ValueError)
-            if target < 0 or target > 27
+            if target < 0 or target >= 36
             else does_not_raise(),
         ]
         for target in range(-36, 2 * 36)


### PR DESCRIPTION
# Description

The limit switches aren't actually needed to protect anything on either the FINESSE or UNIRAS rigs. The positions of the limit switches are currently hardcoded which isn't ideal. Handling them properly (i.e. distinguishing error states caused by hitting the limit switches vs other errors) will be annoying. So let's just disable them.

Unrelated change: I noticed the mirror angle is sometimes displayed to a silly number of DPs in the GUI, so I've rounded it to the nearest degree.

Closes #817.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
