### PR TITLE
Use a longer timeout for EM27 devices

### DIFF
--- a/frog/config.py
+++ b/frog/config.py
@@ -51,6 +51,9 @@ EM27_SENSORS_URL = "http://{host}/diag_autom.htm"
 EM27_SENSORS_POLL_INTERVAL = 60.0
 """Poll rate for EM27 properties."""
 
+DEFAULT_EM27_HTTP_TIMEOUT = 20.0
+"""The default HTTP timeout for the EM27Sensors and OPUSInterface devices."""
+
 DECADES_HOST = "localhost"
 """The IP address or hostname of the DECADES server."""
 

--- a/frog/hardware/plugins/sensors/em27_sensors.py
+++ b/frog/hardware/plugins/sensors/em27_sensors.py
@@ -6,6 +6,7 @@ This is used to scrape the PSF27Sensor data table off the server.
 from decimal import Decimal
 
 from frog.config import (
+    DEFAULT_EM27_HTTP_TIMEOUT,
     DEFAULT_HTTP_TIMEOUT,
     EM27_HOST,
     EM27_SENSORS_POLL_INTERVAL,
@@ -112,7 +113,7 @@ class EM27Sensors(
         self,
         host: str = EM27_HOST,
         poll_interval: float = EM27_SENSORS_POLL_INTERVAL,
-        timeout: float = DEFAULT_HTTP_TIMEOUT,
+        timeout: float = DEFAULT_EM27_HTTP_TIMEOUT,
     ) -> None:
         """Create a new EM27Sensors.
 

--- a/frog/hardware/plugins/spectrometer/opus_interface.py
+++ b/frog/hardware/plugins/spectrometer/opus_interface.py
@@ -12,7 +12,7 @@ from bs4 import BeautifulSoup
 from PySide6.QtCore import QTimer
 
 from frog.config import (
-    DEFAULT_HTTP_TIMEOUT,
+    DEFAULT_EM27_HTTP_TIMEOUT,
     DEFAULT_OPUS_HOST,
     DEFAULT_OPUS_POLLING_INTERVAL,
     DEFAULT_OPUS_PORT,
@@ -84,7 +84,7 @@ class OPUSInterface(
         host: str = DEFAULT_OPUS_HOST,
         port: int = DEFAULT_OPUS_PORT,
         polling_interval: float = DEFAULT_OPUS_POLLING_INTERVAL,
-        timeout: float = DEFAULT_HTTP_TIMEOUT,
+        timeout: float = DEFAULT_EM27_HTTP_TIMEOUT,
     ) -> None:
         """Create a new OPUSInterface.
 


### PR DESCRIPTION
# Description

If a user starts a calibration at the point where we're making a request, it can take a really long time for a response and can time out. Fix by increasing the timeout for EM27 devices (`EM27Sensors` and `OPUSInterface`).

Fixes #815.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
