### PR TITLE
Fix: ST10Controller: Don't handle move end events when closing

### DIFF
--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -236,6 +236,10 @@ class ST10Controller(
         if not self.serial.is_open:
             return
 
+        # Don't handle move end events because they will likely happen after the device
+        # is disconnected
+        self._reader.async_read_completed.disconnect()
+
         try:
             self.stop_moving()
             self.move_to("nadir")


### PR DESCRIPTION
# Description

If you close FROG while the stepper motor is still moving, you can end up with `ST10Controller._on_move_end` being invoked after the serial device is closed, which will trigger an uncaught exception. Fix by disconnecting the slots from `_reader.async_read_completed` on close.

I think this was caused by my last fix to the `ST10Controller` code. It's like playing whack-a-mole :laughing: 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
