### PR TITLE
Fix: Send `device.closed` message if device fails to connect

### DIFF
--- a/frog/hardware/manage_devices.py
+++ b/frog/hardware/manage_devices.py
@@ -68,6 +68,7 @@ def _open_device(
     except Exception as error:
         logging.error(f"Failed to open {instance!s} device: {error!s}")
         pub.sendMessage(f"device.error.{instance!s}", instance=instance, error=error)
+        pub.sendMessage(f"device.closed.{instance!s}", instance=instance)
 
 
 def _try_close_device(device: Device) -> None:


### PR DESCRIPTION
# Description

Another tiny fix to review!

While the `device.error` message will be sent and this *normally* triggers a `device.closed` message too, this won't happen if a device error occurs during initialisation, so we should send the message separately, otherwise the GUI can be stuck in a "device connecting" state.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
