### PR TITLE
Fix: Confirm whether to close measure script dialog when user presses escape

### DIFF
--- a/frog/gui/measure_script/script_run_dialog.py
+++ b/frog/gui/measure_script/script_run_dialog.py
@@ -1,7 +1,8 @@
 """Provides a dialog to display the progress of a running measure script."""
 
 from pubsub import pub
-from PySide6.QtGui import QCloseEvent, QHideEvent
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QCloseEvent, QHideEvent, QKeyEvent
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -120,3 +121,10 @@ class ScriptRunDialog(QDialog):
         """Hide the dialog."""
         super().hideEvent(event)
         self._stop_dlg.hide()
+
+    def keyPressEvent(self, event: QKeyEvent):
+        """Intercept when user presses escape to confirm whether to close dialog."""
+        if event.key() == Qt.Key.Key_Escape:
+            self.close()
+        else:
+            super().keyPressEvent(event)

--- a/frog/gui/measure_script/script_run_dialog.py
+++ b/frog/gui/measure_script/script_run_dialog.py
@@ -125,6 +125,7 @@ class ScriptRunDialog(QDialog):
     def keyPressEvent(self, event: QKeyEvent):
         """Intercept when user presses escape to confirm whether to close dialog."""
         if event.key() == Qt.Key.Key_Escape:
-            self.close()
+            # Show the confirmation dialog instead of directly closing
+            self._stop_dlg.show()
         else:
             super().keyPressEvent(event)


### PR DESCRIPTION
# Description

By default, pressing escape triggers the reject event, which closes the window unconditionally. We want to confirm whether to close the measure script dialog, so intercept the keypress in this case.

Fixes #799.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
