### PR TITLE
ST10Controller: Unconditionally stop motor before move

### DIFF
--- a/frog/gui/measure_script/script.py
+++ b/frog/gui/measure_script/script.py
@@ -244,9 +244,6 @@ class ScriptRunner(StateMachine):
         self.current_measurement_count: int
         """How many times a measurement has been recorded at the current angle."""
 
-        # Send stop command in case motor is moving
-        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.stop")
-
         # Actions to control the script
         pub.subscribe(self.abort, "measure_script.abort")
         pub.subscribe(self.pause, "measure_script.pause")

--- a/frog/gui/stepper_motor_view.py
+++ b/frog/gui/stepper_motor_view.py
@@ -66,9 +66,6 @@ class StepperMotorControl(DevicePanel):
 
     def _preset_clicked(self, btn: QPushButton) -> None:
         """Move the stepper motor to preset position."""
-        # If the motor is already moving, stop it now
-        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.stop")
-
         target = float(self.angle.value()) if btn is self.goto else btn.text().lower()
         pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target=target)
 

--- a/frog/hardware/plugins/stepper_motor/dummy.py
+++ b/frog/hardware/plugins/stepper_motor/dummy.py
@@ -68,6 +68,7 @@ class DummyStepperMotor(
         Args:
             step: Which step position to move to
         """
+        self._move_end_timer.stop()
         logging.info(f"Moving stepper motor to step {step}")
         self._new_step = step
         self._move_end_timer.start()

--- a/frog/hardware/plugins/stepper_motor/st10_controller.py
+++ b/frog/hardware/plugins/stepper_motor/st10_controller.py
@@ -237,7 +237,6 @@ class ST10Controller(
             return
 
         try:
-            self.stop_moving()
             self.move_to("nadir")
         except Exception as e:
             logging.error(f"Failed to reset mirror to downward position: {e}")
@@ -418,6 +417,8 @@ class ST10Controller(
             SerialTimeoutException: Timed out waiting for response from device
             ST10ControllerError: Malformed message received from device
         """
+        self.stop_moving()
+
         # "Feed to position"
         self._write_check(f"FP{step}")
         self._notify_on_stopped()

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -13,13 +13,10 @@ from frog.gui.measure_script.script import Script, ScriptRunner
 from frog.spectrometer_status import SpectrometerStatus
 
 
-def test_init(subscribe_mock: MagicMock, sendmsg_mock: MagicMock) -> None:
+def test_init(subscribe_mock: MagicMock) -> None:
     """Test ScriptRunner's constructor."""
     script = Script(Path(), 1, ())
     runner = ScriptRunner(script)
-
-    # Check we're stopping the motor
-    sendmsg_mock.assert_called_once_with(f"device.{STEPPER_MOTOR_TOPIC}.stop")
 
     # Check we're subscribed to abort messages
     subscribe_mock.assert_has_calls(

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -49,8 +49,7 @@ def test_preset_clicked(preset: str, sendmsg_mock: MagicMock, qtbot: QtBot) -> N
 
     # The motor should be stopped and then moved to this preset
     control._preset_clicked(btn)
-    sendmsg_mock.assert_any_call(f"device.{STEPPER_MOTOR_TOPIC}.stop")
-    sendmsg_mock.assert_any_call(
+    sendmsg_mock.assert_called_once_with(
         f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target=preset
     )
 
@@ -64,8 +63,7 @@ def test_goto_clicked(sendmsg_mock: MagicMock, qtbot: QtBot) -> None:
 
         # The motor should be stopped then moved to 123°
         control._preset_clicked(control.goto)
-        sendmsg_mock.assert_any_call(f"device.{STEPPER_MOTOR_TOPIC}.stop")
-        sendmsg_mock.assert_any_call(
+        sendmsg_mock.assert_called_once_with(
             f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target=123.0
         )
 


### PR DESCRIPTION
# Description

If you send two consecutive move commands to the ST10 controller it'll move to the first position before moving to the second. This might be a useful feature in some cases, but it's not something we need. Let's simplify the API for `ST10Controller` by sending a stop command before every move command so that we don't have to worry about doing it on the frontend side.

Closes #715.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
