### PR TITLE
Point mirror downwards on measure script end

### DIFF
--- a/frog/gui/measure_script/script.py
+++ b/frog/gui/measure_script/script.py
@@ -200,9 +200,7 @@ class ScriptRunner(StateMachine):
     """Finish the moving stage."""
     finish_waiting_for_move = waiting_to_move.to(moving)
     """Stop waiting and start the next move."""
-    cancel_move = moving.to(
-        not_running, after=lambda: pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.stop")
-    )
+    cancel_move = moving.to(not_running)
     """Cancel the current movement."""
     start_measuring = waiting_to_measure.to(measuring)
     """Start recording for the current measurement."""
@@ -278,6 +276,9 @@ class ScriptRunner(StateMachine):
         pub.unsubscribe(
             self._on_spectrometer_error, f"device.error.{SPECTROMETER_TOPIC}"
         )
+
+        # Reset mirror to point downwards on measure script end
+        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target="nadir")
 
         # Send message signalling that the measure script is no longer running
         pub.sendMessage("measure_script.end")

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -113,8 +113,14 @@ def test_finish_moving(
         any_order=True,
     )
 
-    # Check that this message is sent on the last iteration
-    sendmsg_mock.assert_called_once_with("measure_script.end")
+    sendmsg_mock.assert_has_calls(
+        (
+            # Point mirror downwards
+            call(f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target="nadir"),
+            # Notify listeners that measure script has finished
+            call("measure_script.end"),
+        )
+    )
 
 
 def test_finish_moving_paused(


### PR DESCRIPTION
# Description

This is to prevent debris accumulating on the mirror between measure script runs.

Closes #793.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
