### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "FROG"
-version = "2.1.0rc1"
+version = "3.0.0"
 description = "A graphical user interface for controlling and monitoring an interferometer device."
 authors = [
     "Alex Dewar <a.dewar@imperial.ac.uk>",


### PR DESCRIPTION
Essentially this is a minor release (according to semantic versioning), but because of the FROG rebranding, I think it would be cleaner to start afresh with a new major version. It'll be easier to remember that everything before v3 is called FINESSE and everything after is called FROG.