### PR TITLE
Allow non-USB serial ports

### DIFF
--- a/docs/hardware_sets.md
+++ b/docs/hardware_sets.md
@@ -54,7 +54,8 @@ is also a YAML object, containing key-value pairs for each of the device paramet
 [Hardware] again). If any of the parameters are omitted, their default values will be
 used.
 
-Note that the port names are in a FROG-specific format. The string is composed of the
+Note that the port names for USB devices are in a FROG-specific format (non-USB serial
+devices are just listed with the port name, e.g. COM3). The string is composed of the
 USB vendor and product IDs and (optionally) a number to distinguish ports which share
 all these properties (as happens with USB-to-serial devices with multiple ports, for
 example). The easiest way to figure out these strings is to run FROG and click on

--- a/src/frog/hardware/plugins/temperature/dp9800.py
+++ b/src/frog/hardware/plugins/temperature/dp9800.py
@@ -97,7 +97,7 @@ class DP9800(SerialDevice, TemperatureMonitorBase, description="DP9800"):
         """Create a new DP9800.
 
         Args:
-            port: Description of USB port (vendor ID + product ID)
+            port: Name/description of serial port
             baudrate: Baud rate of port
         """
         SerialDevice.__init__(self, port, baudrate)

--- a/src/frog/hardware/serial_device.py
+++ b/src/frog/hardware/serial_device.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import Counter
 
 from serial import Serial, SerialException
 from serial.tools.list_ports import comports
@@ -60,7 +61,7 @@ def _get_usb_serial_ports(refresh: bool = False) -> dict[str, str]:
 
     # Keep track of ports with the same vendor and product ID and assign them an
     # additional number to distinguish them
-    counter: dict[tuple[int, int], int] = {}
+    counter: Counter[tuple[int, int]] = Counter()
     _serial_ports = {}
     for port in sorted(comports(), key=lambda port: _get_port_parts(port.device)):
         # Vendor ID is a USB-specific field, so we can use this to check whether the
@@ -69,9 +70,6 @@ def _get_usb_serial_ports(refresh: bool = False) -> dict[str, str]:
             continue
 
         key = (port.vid, port.pid)
-        if key not in counter:
-            counter[key] = 0
-
         _serial_ports[_port_info_to_str(*key, counter[key])] = port.device
         counter[key] += 1
 

--- a/tests/hardware/test_serial_device.py
+++ b/tests/hardware/test_serial_device.py
@@ -10,17 +10,17 @@ from frog.hardware.serial_device import (
     SerialDevice,
     _create_serial,
     _get_port_parts,
-    _get_usb_serial_ports,
+    _get_serial_ports,
     _port_info_to_str,
 )
 
 
 @patch("frog.hardware.serial_device.comports")
-def test_get_usb_serial_ports_cached(comports_mock: Mock) -> None:
-    """Check that _get_usb_serial_ports() works when results have been cached."""
+def test_get_serial_ports_cached(comports_mock: Mock) -> None:
+    """Check that _get_serial_ports() works when results have been cached."""
     serial_ports = {_port_info_to_str(1, 2, 0): "COM1"}
     with patch("frog.hardware.serial_device._serial_ports", serial_ports):
-        assert _get_usb_serial_ports() == serial_ports
+        assert _get_serial_ports() == serial_ports
         comports_mock.assert_not_called()
 
 
@@ -28,10 +28,10 @@ def test_get_usb_serial_ports_cached(comports_mock: Mock) -> None:
     "refresh,serial_ports", ((False, None), (True, {"key": "value"}))
 )
 @patch("frog.hardware.serial_device.comports")
-def test_get_usb_serial_ports(
+def test_get_serial_ports(
     comports_mock: Mock, refresh: bool, serial_ports: Any
 ) -> None:
-    """Test _get_usb_serial_ports()."""
+    """Test _get_serial_ports()."""
     VID = 1
     PID = 2
 
@@ -51,8 +51,9 @@ def test_get_usb_serial_ports(
     comports_mock.return_value = ports
 
     with patch("frog.hardware.serial_device._serial_ports", serial_ports):
-        assert _get_usb_serial_ports(refresh) == {
+        assert _get_serial_ports(refresh) == {
             _port_info_to_str(VID, PID, 0): "COM1",
+            "COM2": "COM2",
             _port_info_to_str(VID, PID, 1): "COM3",
         }
 
@@ -68,7 +69,7 @@ def test_get_port_parts() -> None:
 
 
 @pytest.mark.parametrize("refresh", (False, True))
-@patch("frog.hardware.serial_device._get_usb_serial_ports")
+@patch("frog.hardware.serial_device._get_serial_ports")
 @patch("frog.hardware.serial_device.Serial")
 def test_create_serial_success(
     serial_mock: Mock, get_serial_ports_mock: Mock, refresh: bool
@@ -84,7 +85,7 @@ def test_create_serial_success(
 
 
 @pytest.mark.parametrize("refresh", (False, True))
-@patch("frog.hardware.serial_device._get_usb_serial_ports")
+@patch("frog.hardware.serial_device._get_serial_ports")
 @patch("frog.hardware.serial_device.Serial")
 def test_create_serial_fail_no_device(
     serial_mock: Mock, get_serial_ports_mock: Mock, refresh: bool
@@ -96,7 +97,7 @@ def test_create_serial_fail_no_device(
 
 
 @pytest.mark.parametrize("refresh", (False, True))
-@patch("frog.hardware.serial_device._get_usb_serial_ports")
+@patch("frog.hardware.serial_device._get_serial_ports")
 @patch("frog.hardware.serial_device.Serial")
 def test_create_serial_fail_error(
     serial_mock: Mock, get_serial_ports_mock: Mock, refresh: bool


### PR DESCRIPTION
# Description

We need to add support for an ethernet-based serial adapter (#640), but the code currently only considers USB serial ports. Change it so all ports are displayed and selectable. For non-USB ports, we just display the port name (e.g. `COM5`) instead of the USB product and vendor IDs.

On my machine I now get **31** serial devices listed on my laptop (all beginning with `/dev/ttyS*`) with no devices connected, which is kind of horrid. I assume they're all related to internal devices in some way. Hopefully there won't be so many on the deployed device, but we'll have to see what @jonemurray says. I couldn't see a sane way to filter them, but if it's a Linux-only problem then I guess it's not the end of the world.

The serial adapter comes with software which maps the device to virtual COM ports, so this should be sufficient to use it. There is a standard for ethernet serial devices ([RFC2217](https://datatracker.ietf.org/doc/html/rfc2217)) and the device *may* implement it, though I haven't checked. PySerial provides experimental support for this protocol, but "experimental" probably isn't good enough for our purposes, and the package seems to have been unmaintained for several years at this point so I imagine it'll remain experimental for the foreseeable future. It might be worth seeing if we can make this work at some point purely for ease of development on non-Windows machines, but we should use their virtual COM-port software for actual experiments.

PS - Unrelated, but after a system upgrade I got error messages about a missing `libxml2.so.2` when trying to run FROG. Installing `libxml2-legacy` fixed it.

Closes #640.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
