### PR TITLE
Use `uv_build` build backend cf. `hatchling`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ docs = [
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.8.3,<0.9.0"]
+build-backend = "uv_build"
 
 [tool.ruff]
 target-version = "py313"


### PR DESCRIPTION
It seems that there is a `uv` build backend that we could be using. I suspect it doesn't make much odds and we're not doing many builds anyway, but let's use `uv_build` as it's the recommended default.

I've tried it locally and it seems to work (very quickly!).