### PR TITLE
Fix paths in API docs generation script

### DIFF
--- a/docs/gen_ref_nav.py
+++ b/docs/gen_ref_nav.py
@@ -7,11 +7,12 @@ import mkdocs_gen_files
 nav = mkdocs_gen_files.Nav()
 
 for path in sorted(Path("src/frog").glob("**/*.py")):
-    module_path = path.relative_to(".").with_suffix("")
-    doc_path = Path(*path.parts[1:]).relative_to(".").with_suffix(".md")
+    path = path.relative_to("src")
+    module_path = path.with_suffix("")
+    doc_path = path.with_suffix(".md")
     full_doc_path = Path("reference", doc_path)
 
-    parts = list(module_path.parts[1:])
+    parts = list(module_path.parts)
     if ".array_cache" in parts:
         continue
     elif parts[-1] == "__init__":
@@ -26,7 +27,7 @@ for path in sorted(Path("src/frog").glob("**/*.py")):
         ident = ".".join(parts)
         print("::: " + ident, file=fd)
 
-    mkdocs_gen_files.set_edit_path(full_doc_path, Path("..", *path.parts[1:]))
+    mkdocs_gen_files.set_edit_path(full_doc_path, Path("..", *path.parts))
 
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/docs/gen_ref_nav.py
+++ b/docs/gen_ref_nav.py
@@ -6,12 +6,12 @@ import mkdocs_gen_files
 
 nav = mkdocs_gen_files.Nav()
 
-for path in sorted(Path("frog").glob("**/*.py")):
+for path in sorted(Path("src/frog").glob("**/*.py")):
     module_path = path.relative_to(".").with_suffix("")
-    doc_path = path.relative_to(".").with_suffix(".md")
+    doc_path = Path(*path.parts[1:]).relative_to(".").with_suffix(".md")
     full_doc_path = Path("reference", doc_path)
 
-    parts = list(module_path.parts)
+    parts = list(module_path.parts[1:])
     if ".array_cache" in parts:
         continue
     elif parts[-1] == "__init__":
@@ -26,7 +26,7 @@ for path in sorted(Path("frog").glob("**/*.py")):
         ident = ".".join(parts)
         print("::: " + ident, file=fd)
 
-    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
+    mkdocs_gen_files.set_edit_path(full_doc_path, Path("..", *path.parts[1:]))
 
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())


### PR DESCRIPTION
# Description

It seems like the API doc generation has been broken since I moved the code into a `src` directory as part of the `uv` migration. I've fixed up `gen_ref_nav.py` in a somewhat janky way.

We're still getting spurious warnings (as we always have done) about invalid relative links:

```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/alex/code/FROG/site
INFO    -  Doc file 'hardware.md' contains an unrecognized relative link
           '../reference/frog/hardware', it was left as is. Did you mean
           'reference/frog/hardware/index.md'?
INFO    -  Doc file 'hardware.md' contains an unrecognized relative link
           '../reference/frog/gui', it was left as is. Did you mean
           'reference/frog/gui/index.md'?
INFO    -  Doc file 'hardware.md' contains an unrecognized relative link
           '../reference/frog/hardware/plugins', it was left as is. Did you mean
           'reference/frog/hardware/plugins/index.md'?
INFO    -  Documentation built in 2.23 seconds
```

While we're fixing docs-related stuff, it might be good to sort this too. The other task I'd like to do on that front is to automatically generate the state machine diagrams and user guide when you run `mkdocs`. I have a feeling that this didn't work for some reason, when I tried including these scripts in `mkdocs.yml`.

FYI @AdrianDAlessandro 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [ ] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [x] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
