### PR TITLE
Fix: Stop/cancel broken for `DummyOPUSInterface`

### DIFF
--- a/src/frog/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/src/frog/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -81,7 +81,7 @@ class OPUSStateMachine(StateMachine):
         self._start_connecting()
         self._finish_connecting()
 
-    def stop(self) -> None:
+    def cancel(self) -> None:
         """Stop the current measurement."""
         self._cancel_measuring()
         self._reset_after_cancelling()

--- a/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
@@ -88,7 +88,7 @@ def test_sm_stop(sm: OPUSStateMachine) -> None:
         sm.current_state = OPUSStateMachine.measuring
         observer = _MockObserver()
         sm.add_observer(observer)
-        sm.stop()
+        sm.cancel()
         observer.assert_has_states(
             OPUSStateMachine.cancelling, OPUSStateMachine.connected
         )


### PR DESCRIPTION
# Description

It seems that when we amalgamated the stop and cancel functionality for OPUS devices, we forgot to update one method name, meaning that you can't currently send a stop command to a `DummyOPUSInterface` device. Fix this.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [ ] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
