### PR TITLE
Rework hardware set code and allow option to save current configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "frozendict<3.0.0,>=2.4.6",
     "crc<8.0.0,>=7.1.0",
     "ntplib<1.0.0,>=0.4.0",
+    "python-slugify>=8.0.4",
 ]
 
 [dependency-groups]

--- a/src/frog/gui/hardware_set/device.py
+++ b/src/frog/gui/hardware_set/device.py
@@ -97,17 +97,19 @@ class ActiveDeviceManager(QObject):
         pub.subscribe(self._on_device_closed, "device.closed")
         pub.subscribe(self._on_device_error, "device.error")
 
-    def get_connected_devices(self) -> Iterable[OpenDeviceArgs]:
-        """Get active devices which are connected (not connecting)."""
+    @property
+    def devices(self) -> Mapping[DeviceInstanceRef, ActiveDeviceProperties]:
+        """The current active devices."""
+        return self._active_devices
+
+    @property
+    def connected_devices(self) -> Iterable[OpenDeviceArgs]:
+        """Active devices which are connected (not connecting)."""
         return (
             props.args
             for props in self._active_devices.values()
             if props.state == ConnectionStatus.CONNECTED
         )
-
-    def get_active_devices(self) -> Mapping[DeviceInstanceRef, ActiveDeviceProperties]:
-        """Get the current active devices."""
-        return self._active_devices
 
     def disconnect_all(self) -> None:
         """Disconnect from all devices."""

--- a/src/frog/gui/hardware_set/device.py
+++ b/src/frog/gui/hardware_set/device.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
 from frozendict import frozendict
 from pubsub import pub
+from PySide6.QtCore import QObject, Signal
 
 from frog.device_info import DeviceInstanceRef
+from frog.gui.error_message import show_error_message
 
 
 @dataclass(frozen=True)
@@ -37,6 +39,23 @@ class OpenDeviceArgs:
         return cls(DeviceInstanceRef.from_str(instance), class_name, frozendict(params))
 
 
+@dataclass
+class ActiveDeviceProperties:
+    """The properties of a device that is connecting or connected."""
+
+    args: OpenDeviceArgs
+    """Arguments used to open the device."""
+    state: ConnectionStatus
+    """Whether the device is connecting or connected."""
+
+    def __post_init__(self) -> None:
+        """Check whether user attempted to create for a disconnected device."""
+        if self.state == ConnectionStatus.DISCONNECTED:
+            raise ValueError(
+                "Cannot create ActiveDeviceProperties for disconnected device"
+            )
+
+
 class ConnectionStatus(Enum):
     """The connection state of a device."""
 
@@ -57,3 +76,82 @@ def open_device(
 def close_device(instance: DeviceInstanceRef) -> None:
     """Close a connection to a device."""
     pub.sendMessage("device.close", instance=instance)
+
+
+class ActiveDeviceManager(QObject):
+    """A class used by the frontend to monitor and control backend devices."""
+
+    device_opened = Signal(DeviceInstanceRef, str)
+    device_started_open = Signal(DeviceInstanceRef, str, Mapping)
+    device_closed = Signal(DeviceInstanceRef)
+
+    def __init__(
+        self,
+        active_devices: dict[DeviceInstanceRef, ActiveDeviceProperties] | None = None,
+    ) -> None:
+        """Create a new _ActiveDeviceManager."""
+        super().__init__()
+        self._active_devices = active_devices or {}
+        pub.subscribe(self._on_device_open_start, "device.before_opening")
+        pub.subscribe(self._on_device_open_end, "device.after_opening")
+        pub.subscribe(self._on_device_closed, "device.closed")
+        pub.subscribe(self._on_device_error, "device.error")
+
+    def get_connected_devices(self) -> Iterable[OpenDeviceArgs]:
+        """Get active devices which are connected (not connecting)."""
+        return (
+            props.args
+            for props in self._active_devices.values()
+            if props.state == ConnectionStatus.CONNECTED
+        )
+
+    def get_active_devices(self) -> Mapping[DeviceInstanceRef, ActiveDeviceProperties]:
+        """Get the current active devices."""
+        return self._active_devices
+
+    def disconnect_all(self) -> None:
+        """Disconnect from all devices."""
+        # We need to make a copy because keys will be removed as we close devices
+        for device in list(self._active_devices.keys()):
+            pub.sendMessage("device.close", instance=device)
+
+    def _on_device_open_start(
+        self, instance: DeviceInstanceRef, class_name: str, params: Mapping[str, Any]
+    ) -> None:
+        """Store device open parameters and update GUI."""
+        args = OpenDeviceArgs(instance, class_name, frozendict(params))
+        dev_props = ActiveDeviceProperties(args, ConnectionStatus.CONNECTING)
+        self._active_devices[instance] = dev_props
+        self.device_started_open.emit(instance, class_name, params)
+
+    def _on_device_open_end(self, instance: DeviceInstanceRef, class_name: str) -> None:
+        """Add instance to _connected_devices and update GUI."""
+        dev_props = self._active_devices[instance]
+        dev_props.state = ConnectionStatus.CONNECTED
+        assert dev_props.args.class_name == class_name
+        self.device_opened.emit(instance, class_name)
+
+    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
+        """Remove instance from _connected devices and update GUI."""
+        try:
+            # Remove the device matching this instance type (there should be only one)
+            del self._active_devices[instance]
+        except KeyError:
+            # No device of this type found
+            pass
+        else:
+            self.device_closed.emit(instance)
+
+    def _on_device_error(
+        self, instance: DeviceInstanceRef, error: BaseException
+    ) -> None:
+        """Show an error message when something has gone wrong with the device.
+
+        Todo:
+            The name of the device isn't currently very human readable.
+        """
+        show_error_message(
+            None,
+            f"A fatal error has occurred with the {instance!s} device: {error!s}",
+            title="Device error",
+        )

--- a/src/frog/gui/hardware_set/device_view.py
+++ b/src/frog/gui/hardware_set/device_view.py
@@ -362,14 +362,11 @@ class DeviceControl(QGroupBox):
 
     def _get_connected_device(self, instance: DeviceInstanceRef) -> str | None:
         """Get the class name of the connected device matching instance, if any."""
-        return next(
-            (
-                device.class_name
-                for device in self._device_manager.connected_devices
-                if device.instance == instance
-            ),
-            None,
-        )
+        device = self._device_manager.devices.get(instance, None)
+        if not device or device.state != ConnectionStatus.CONNECTED:
+            return None
+
+        return device.args.class_name
 
     def _on_device_list(
         self, device_types: Mapping[DeviceBaseTypeInfo, Sequence[DeviceTypeInfo]]

--- a/src/frog/gui/hardware_set/device_view.py
+++ b/src/frog/gui/hardware_set/device_view.py
@@ -365,7 +365,7 @@ class DeviceControl(QGroupBox):
         return next(
             (
                 device.class_name
-                for device in self._device_manager.get_connected_devices()
+                for device in self._device_manager.connected_devices
                 if device.instance == instance
             ),
             None,

--- a/src/frog/gui/hardware_set/device_view.py
+++ b/src/frog/gui/hardware_set/device_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from pubsub import pub
@@ -22,8 +22,8 @@ from PySide6.QtWidgets import (
 from frog.device_info import DeviceBaseTypeInfo, DeviceInstanceRef, DeviceTypeInfo
 from frog.gui.error_message import show_error_message
 from frog.gui.hardware_set.device import (
+    ActiveDeviceManager,
     ConnectionStatus,
-    OpenDeviceArgs,
     close_device,
     open_device,
 )
@@ -349,13 +349,12 @@ class DeviceTypeControl(QGroupBox):
 class DeviceControl(QGroupBox):
     """Allows for viewing and connecting to devices."""
 
-    def __init__(self, connected_devices: Set[OpenDeviceArgs]) -> None:
+    def __init__(self, device_manager: ActiveDeviceManager) -> None:
         """Create a new DeviceControl."""
         super().__init__("Device control")
+        self._device_manager = device_manager
         self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.setLayout(QVBoxLayout())
-        self._connected_devices = connected_devices
-        """The devices already connected when the control is created."""
 
         # Retrieve the list of device plugins
         pub.subscribe(self._on_device_list, "device.list.response")
@@ -366,7 +365,7 @@ class DeviceControl(QGroupBox):
         return next(
             (
                 device.class_name
-                for device in self._connected_devices
+                for device in self._device_manager.get_connected_devices()
                 if device.instance == instance
             ),
             None,

--- a/src/frog/gui/hardware_set/hardware_set.py
+++ b/src/frog/gui/hardware_set/hardware_set.py
@@ -15,6 +15,7 @@ from pubsub import pub
 from PySide6.QtCore import QFile
 from PySide6.QtWidgets import QMessageBox
 from schema import And, Const, Optional, Schema
+from slugify import slugify
 
 from frog.config import HARDWARE_SET_USER_PATH
 from frog.gui.error_message import show_error_message
@@ -127,6 +128,18 @@ class HardwareSet:
             for k, v in plain_data.get("devices", {}).items()
         )
         return cls(plain_data["name"], devices, file_path, built_in)
+
+    @classmethod
+    def from_devices(cls, name: str, devices: Iterable[OpenDeviceArgs]) -> HardwareSet:
+        """Save the current hardware configuration with the specified name."""
+        devices = frozenset(devices)
+
+        # We use slugify to remove chars that may not be valid for file names. Note that
+        # only the file name from this path will be used in practice (as the hardware
+        # set will be saved elsewhere)
+        file_path = Path(f"{slugify(name)}.yaml")
+
+        return cls(name, devices, file_path, built_in=False)
 
 
 def _get_new_hardware_set_path(

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -2,14 +2,12 @@
 
 from collections.abc import Mapping, Set
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, cast
 
 from frozendict import frozendict
 from pubsub import pub
 from PySide6.QtWidgets import (
     QDialog,
-    QFileDialog,
     QGroupBox,
     QHBoxLayout,
     QPushButton,
@@ -112,9 +110,6 @@ class HardwareSetsControl(QGroupBox):
         )
         self._disconnect_btn.pressed.connect(self._on_disconnect_btn_pressed)
 
-        import_hw_set_btn = QPushButton("Import config")
-        import_hw_set_btn.pressed.connect(self._import_hardware_set)
-
         self._remove_hw_set_btn = QPushButton("Remove")
         self._remove_hw_set_btn.pressed.connect(self._remove_current_hardware_set)
 
@@ -127,7 +122,6 @@ class HardwareSetsControl(QGroupBox):
         row1.addWidget(self._connect_btn)
         row1.addWidget(self._disconnect_btn)
         row2 = QHBoxLayout()
-        row2.addWidget(import_hw_set_btn)
         row2.addWidget(self._remove_hw_set_btn)
         row2.addWidget(manage_devices_btn)
 
@@ -147,25 +141,6 @@ class HardwareSetsControl(QGroupBox):
             for props in self._active_devices.values()
             if props.state == ConnectionStatus.CONNECTED
         )
-
-    def _import_hardware_set(self) -> None:
-        """Import a hardware set from a file."""
-        file_path, _ = QFileDialog.getOpenFileName(
-            self, "Import hardware set config file", filter="*.yaml"
-        )
-        if not file_path:
-            return
-
-        try:
-            hw_set = HardwareSet.load(Path(file_path))
-        except Exception:
-            show_error_message(
-                self,
-                "Could not load hardware set config file. Is it in the correct format?",
-                "Could not load config file",
-            )
-        else:
-            pub.sendMessage("hardware_set.add", hw_set=hw_set)
 
     def _remove_current_hardware_set(self) -> None:
         """Remove the currently selected hardware set."""

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -117,12 +117,9 @@ class ManageDevicesDialog(QDialog):
         )
         self._save_btn.clicked.connect(self._save_hardware_set)
 
-        buttonbox = QDialogButtonBox()
+        buttonbox = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
         buttonbox.addButton(self._save_btn, QDialogButtonBox.ButtonRole.ActionRole)
-        buttonbox.addButton(
-            QPushButton("Close"), QDialogButtonBox.ButtonRole.RejectRole
-        )
-        buttonbox.rejected.connect(self.reject)
+        buttonbox.accepted.connect(self.accept)
         layout.addWidget(buttonbox)
 
         self.setLayout(layout)

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -179,8 +179,6 @@ class HardwareSetsControl(QGroupBox):
         ):
             device.open()
 
-        self._update_control_state()
-
     def _on_device_open_start(
         self, instance: DeviceInstanceRef, class_name: str, params: Mapping[str, Any]
     ) -> None:
@@ -194,7 +192,6 @@ class HardwareSetsControl(QGroupBox):
     def _on_disconnect_btn_pressed(self) -> None:
         """Disconnect from all devices in current hardware set."""
         self._device_manager.disconnect_all()
-        self._update_control_state()
 
     def _on_device_open_end(self, instance: DeviceInstanceRef, class_name: str) -> None:
         """Add instance to _connected_devices and update GUI."""

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -134,7 +134,7 @@ class ManageDevicesDialog(QDialog):
         if name := HardwareSetNameDialog(self).show_and_get_name():
             # Create a hardware set from the currently connected devices
             hw_set = HardwareSet.from_devices(
-                name, self._device_manager.get_connected_devices()
+                name, self._device_manager.connected_devices
             )
 
             # Save it and add to the list of hardware sets displayed in the GUI
@@ -150,7 +150,7 @@ class ManageDevicesDialog(QDialog):
         don't count) and disabled otherwise.
         """
         any_devices_connected = bool(
-            next(self._device_manager.get_connected_devices(), None)  # type: ignore
+            next(self._device_manager.connected_devices, None)  # type: ignore
         )
         self._save_btn.setEnabled(any_devices_connected)
 
@@ -233,12 +233,12 @@ class HardwareSetsControl(QGroupBox):
         """Enable or disable the connect and disconnect buttons as appropriate."""
         # Enable the "Connect" button if there are any devices left to connect for this
         # hardware set
-        connected_devices = set(self._device_manager.get_connected_devices())
+        connected_devices = set(self._device_manager.connected_devices)
         all_connected = connected_devices.issuperset(
             self._combo.current_hardware_set_devices
         )
         any_devices_connecting = len(connected_devices) < len(
-            self._device_manager.get_active_devices()
+            self._device_manager.devices
         )
         self._connect_btn.setEnabled(not any_devices_connecting and not all_connected)
 
@@ -267,7 +267,7 @@ class HardwareSetsControl(QGroupBox):
 
         # Open each of the devices in turn
         for device in self._combo.current_hardware_set_devices.difference(
-            self._device_manager.get_active_devices()
+            self._device_manager.devices
         ):
             device.open()
 
@@ -287,7 +287,7 @@ class HardwareSetsControl(QGroupBox):
 
     def _on_device_open_end(self, instance: DeviceInstanceRef, class_name: str) -> None:
         """Add instance to _connected_devices and update GUI."""
-        dev_props = self._device_manager.get_active_devices()[instance]
+        dev_props = self._device_manager.devices[instance]
 
         # Remember last opened device
         settings.setValue(f"device/type/{instance!s}", class_name)

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -111,7 +111,7 @@ class ManageDevicesDialog(QDialog):
         layout = QVBoxLayout()
         layout.addWidget(DeviceControl(device_manager))
 
-        self._save_btn = QPushButton("Save")
+        self._save_btn = QPushButton("Save device configuration")
         self._save_btn.setIcon(
             self.style().standardIcon(QStyle.StandardPixmap.SP_DialogSaveButton)
         )

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -8,6 +8,7 @@ from frozendict import frozendict
 from pubsub import pub
 from PySide6.QtWidgets import (
     QDialog,
+    QDialogButtonBox,
     QGroupBox,
     QHBoxLayout,
     QPushButton,
@@ -75,6 +76,14 @@ class ManageDevicesDialog(QDialog):
 
         layout = QVBoxLayout()
         layout.addWidget(DeviceControl(connected_devices))
+
+        buttonbox = QDialogButtonBox()
+        buttonbox.addButton(
+            QPushButton("Close"), QDialogButtonBox.ButtonRole.RejectRole
+        )
+        buttonbox.rejected.connect(self.reject)
+        layout.addWidget(buttonbox)
+
         self.setLayout(layout)
 
 

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -67,7 +67,7 @@ class HardwareSetNameDialog(QDialog):
         )
         btn_box.accepted.connect(self.accept)
         btn_box.rejected.connect(self.reject)
-        layout.addWidget(btn_box)
+        layout.addWidget(btn_box, 1, 0, 1, 2)
 
         self.setLayout(layout)
 

--- a/src/frog/gui/hardware_set/hardware_sets_view.py
+++ b/src/frog/gui/hardware_set/hardware_sets_view.py
@@ -53,10 +53,10 @@ class HardwareSetNameDialog(QDialog):
     def __init__(self, parent: QWidget) -> None:
         """Create a new HardwareSetNameDialog."""
         super().__init__(parent)
-        self.setWindowTitle("Hardware set name")
+        self.setWindowTitle("Device configuration name")
 
         layout = QGridLayout()
-        layout.addWidget(QLabel("Name for new hardware set:"), 0, 0)
+        layout.addWidget(QLabel("Name for device configuration:"), 0, 0)
 
         self._name_widget = QLineEdit()
         self._name_widget.setMinimumSize(200, self._name_widget.minimumHeight())
@@ -90,7 +90,7 @@ class HardwareSetNameDialog(QDialog):
             msgbox = QMessageBox(
                 QMessageBox.Icon.Critical,
                 "No name provided",
-                "You must provide a name for the hardware set",
+                "You must provide a name for the device configuration",
             )
             msgbox.exec()
 
@@ -163,7 +163,7 @@ class HardwareSetsControl(QGroupBox):
         device_manager: ActiveDeviceManager | None = None,
     ) -> None:
         """Create a new HardwareSetsControl."""
-        super().__init__("Hardware set")
+        super().__init__("Devices")
 
         if not device_manager:
             device_manager = ActiveDeviceManager()

--- a/src/frog/gui/hardware_set/menu.py
+++ b/src/frog/gui/hardware_set/menu.py
@@ -1,6 +1,13 @@
 """Provides a menu for working with hardware sets."""
 
-from PySide6.QtWidgets import QMenu
+from pathlib import Path
+
+from pubsub import pub
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QFileDialog, QMenu
+
+from frog.gui.error_message import show_error_message
+from frog.gui.hardware_set.hardware_set import HardwareSet
 
 
 class HardwareSetsMenu(QMenu):
@@ -9,3 +16,26 @@ class HardwareSetsMenu(QMenu):
     def __init__(self) -> None:
         """Create a new HardwareSetsMenu."""
         super().__init__("Hardware sets")
+
+        import_action = QAction("Import from file", self)
+        import_action.triggered.connect(self._import_hardware_set)
+        self.addAction(import_action)
+
+    def _import_hardware_set(self) -> None:
+        """Import a hardware set from a file."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self, "Import hardware set config file", filter="*.yaml"
+        )
+        if not file_path:
+            return
+
+        try:
+            hw_set = HardwareSet.load(Path(file_path))
+        except Exception:
+            show_error_message(
+                self,
+                "Could not load hardware set config file. Is it in the correct format?",
+                "Could not load config file",
+            )
+        else:
+            pub.sendMessage("hardware_set.add", hw_set=hw_set)

--- a/src/frog/gui/hardware_set/menu.py
+++ b/src/frog/gui/hardware_set/menu.py
@@ -1,0 +1,11 @@
+"""Provides a menu for working with hardware sets."""
+
+from PySide6.QtWidgets import QMenu
+
+
+class HardwareSetsMenu(QMenu):
+    """A menu for performing operations on hardware sets."""
+
+    def __init__(self) -> None:
+        """Create a new HardwareSetsMenu."""
+        super().__init__("Hardware sets")

--- a/src/frog/gui/hardware_set/menu.py
+++ b/src/frog/gui/hardware_set/menu.py
@@ -15,7 +15,7 @@ class HardwareSetsMenu(QMenu):
 
     def __init__(self) -> None:
         """Create a new HardwareSetsMenu."""
-        super().__init__("Hardware sets")
+        super().__init__("Devices")
 
         import_action = QAction("Import from file", self)
         import_action.triggered.connect(self._import_hardware_set)
@@ -24,7 +24,7 @@ class HardwareSetsMenu(QMenu):
     def _import_hardware_set(self) -> None:
         """Import a hardware set from a file."""
         file_path, _ = QFileDialog.getOpenFileName(
-            self, "Import hardware set config file", filter="*.yaml"
+            self, "Import device configuration file", filter="*.yaml"
         )
         if not file_path:
             return
@@ -34,8 +34,9 @@ class HardwareSetsMenu(QMenu):
         except Exception:
             show_error_message(
                 self,
-                "Could not load hardware set config file. Is it in the correct format?",
-                "Could not load config file",
+                "Could not load device configuration file. "
+                "Is it in the correct format?",
+                "Could not load device configuration",
             )
         else:
             pub.sendMessage("hardware_set.add", hw_set=hw_set)

--- a/src/frog/gui/main_window.py
+++ b/src/frog/gui/main_window.py
@@ -21,6 +21,7 @@ from frog.config import (
 from frog.gui.data_file_view import DataFileControl
 from frog.gui.docs_view import DocsViewer
 from frog.gui.hardware_set.hardware_sets_view import HardwareSetsControl
+from frog.gui.hardware_set.menu import HardwareSetsMenu
 from frog.gui.logs_view import LogLocationOpen, LogOpen
 from frog.gui.measure_script.script_view import ScriptControl
 from frog.gui.sensors_panel import SensorsPanel
@@ -41,6 +42,9 @@ class MainWindow(QMainWindow):
         self.setWindowTitle(f"{APP_NAME} v{APP_VERSION}")
 
         set_uncaught_exception_handler(self)
+
+        hw_sets_menu = HardwareSetsMenu()
+        self.menuBar().addMenu(hw_sets_menu)
 
         open_log = LogOpen(self)
         open_log_location = LogLocationOpen(self)

--- a/tests/gui/hardware_set/conftest.py
+++ b/tests/gui/hardware_set/conftest.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pytest
 
 from frog.gui.hardware_set.device import OpenDeviceArgs
-from frog.gui.hardware_set.hardware_set import HardwareSet
+from frog.gui.hardware_set.hardware_set import (
+    HardwareSet,
+)
 
 _HW_SETS = (
     HardwareSet(

--- a/tests/gui/hardware_set/conftest.py
+++ b/tests/gui/hardware_set/conftest.py
@@ -6,9 +6,7 @@ from pathlib import Path
 import pytest
 
 from frog.gui.hardware_set.device import OpenDeviceArgs
-from frog.gui.hardware_set.hardware_set import (
-    HardwareSet,
-)
+from frog.gui.hardware_set.hardware_set import HardwareSet
 
 _HW_SETS = (
     HardwareSet(

--- a/tests/gui/hardware_set/test_active_device_manager.py
+++ b/tests/gui/hardware_set/test_active_device_manager.py
@@ -1,0 +1,287 @@
+"""Test the ActiveDeviceManager class."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from frozendict import frozendict
+
+from frog.device_info import DeviceInstanceRef
+from frog.gui.hardware_set.device import (
+    ActiveDeviceManager,
+    ActiveDeviceProperties,
+    ConnectionStatus,
+    OpenDeviceArgs,
+)
+
+
+@pytest.fixture
+def sample_device_args() -> OpenDeviceArgs:
+    """Create sample OpenDeviceArgs for testing."""
+    return OpenDeviceArgs(
+        instance=DeviceInstanceRef("test_base_type", "test_name"),
+        class_name="TestDevice",
+        params=frozendict({"param1": "value1", "param2": 42}),
+    )
+
+
+@pytest.fixture
+def sample_device_properties(
+    sample_device_args: OpenDeviceArgs,
+) -> ActiveDeviceProperties:
+    """Create sample ActiveDeviceProperties for testing."""
+    return ActiveDeviceProperties(
+        args=sample_device_args,
+        state=ConnectionStatus.CONNECTED,
+    )
+
+
+@pytest.fixture
+def active_devices_dict(
+    sample_device_properties: ActiveDeviceProperties,
+) -> dict[DeviceInstanceRef, ActiveDeviceProperties]:
+    """Create a sample active devices dictionary for testing."""
+    return {sample_device_properties.args.instance: sample_device_properties}
+
+
+def test_init_empty(subscribe_mock: MagicMock, qtbot) -> None:
+    """Test initialization with no active devices."""
+    manager = ActiveDeviceManager()
+
+    assert manager._active_devices == {}
+    assert len(manager.devices) == 0
+    assert list(manager.connected_devices) == []
+
+    # Verify all required subscriptions
+    expected_calls = [
+        ("device.before_opening", manager._on_device_open_start),
+        ("device.after_opening", manager._on_device_open_end),
+        ("device.closed", manager._on_device_closed),
+        ("device.error", manager._on_device_error),
+    ]
+
+    for topic, callback in expected_calls:
+        subscribe_mock.assert_any_call(callback, topic)
+
+    assert subscribe_mock.call_count == 4
+
+
+def test_init_with_active_devices(
+    active_devices_dict: dict[DeviceInstanceRef, ActiveDeviceProperties],
+    subscribe_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test initialization with pre-existing active devices."""
+    manager = ActiveDeviceManager(active_devices_dict)
+
+    assert manager._active_devices is active_devices_dict
+    assert len(manager.devices) == 1
+    expected_device = next(iter(active_devices_dict.values())).args
+    assert list(manager.connected_devices) == [expected_device]
+
+
+def test_devices_property(
+    active_devices_dict: dict[DeviceInstanceRef, ActiveDeviceProperties],
+    subscribe_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the devices property returns the correct mapping."""
+    manager = ActiveDeviceManager(active_devices_dict)
+    devices = manager.devices
+
+    assert devices == active_devices_dict
+    # Ensure it's a mapping, not the actual dict for encapsulation
+    assert type(devices) is dict
+
+
+def test_connected_devices_property_empty(subscribe_mock: MagicMock, qtbot) -> None:
+    """Test connected_devices property when no devices are connected."""
+    manager = ActiveDeviceManager()
+    connected = list(manager.connected_devices)
+
+    assert connected == []
+
+
+def test_connected_devices_property_mixed_states(
+    sample_device_args: OpenDeviceArgs,
+    subscribe_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test connected_devices property filters out connecting devices."""
+    connecting_device = ActiveDeviceProperties(
+        args=OpenDeviceArgs(
+            instance=DeviceInstanceRef("connecting_type"),
+            class_name="ConnectingDevice",
+            params=frozendict(),
+        ),
+        state=ConnectionStatus.CONNECTING,
+    )
+
+    connected_device = ActiveDeviceProperties(
+        args=sample_device_args,
+        state=ConnectionStatus.CONNECTED,
+    )
+
+    active_devices = {
+        connecting_device.args.instance: connecting_device,
+        connected_device.args.instance: connected_device,
+    }
+
+    manager = ActiveDeviceManager(active_devices)
+    connected = list(manager.connected_devices)
+
+    assert len(connected) == 1
+    assert connected[0] == sample_device_args
+
+
+def test_on_device_open_start(subscribe_mock: MagicMock, qtbot) -> None:
+    """Test _on_device_open_start method."""
+    manager = ActiveDeviceManager()
+
+    instance = DeviceInstanceRef("test_type", "test_name")
+    class_name = "TestDevice"
+    params = {"param1": "value1"}
+
+    with qtbot.waitSignal(manager.device_started_open) as blocker:
+        manager._on_device_open_start(instance, class_name, params)
+
+    # Check signal emission
+    assert blocker.args == [instance, class_name, params]
+
+    # Check internal state
+    assert instance in manager._active_devices
+    device_props = manager._active_devices[instance]
+    assert device_props.args.instance == instance
+    assert device_props.args.class_name == class_name
+    assert device_props.args.params == frozendict(params)
+    assert device_props.state == ConnectionStatus.CONNECTING
+
+
+def test_on_device_open_end(
+    sample_device_properties: ActiveDeviceProperties,
+    subscribe_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test _on_device_open_end method."""
+    # Start with a connecting device
+    connecting_props = ActiveDeviceProperties(
+        args=sample_device_properties.args,
+        state=ConnectionStatus.CONNECTING,
+    )
+    active_devices = {sample_device_properties.args.instance: connecting_props}
+    manager = ActiveDeviceManager(active_devices)
+
+    instance = sample_device_properties.args.instance
+    class_name = sample_device_properties.args.class_name
+
+    with qtbot.waitSignal(manager.device_opened) as blocker:
+        manager._on_device_open_end(instance, class_name)
+
+    # Check signal emission
+    assert blocker.args == [instance, class_name]
+
+    # Check state change
+    device_props = manager._active_devices[instance]
+    assert device_props.state == ConnectionStatus.CONNECTED
+
+
+def test_on_device_closed_existing_device(
+    active_devices_dict: dict[DeviceInstanceRef, ActiveDeviceProperties],
+    subscribe_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test _on_device_closed method with an existing device."""
+    manager = ActiveDeviceManager(active_devices_dict)
+    instance = next(iter(active_devices_dict.keys()))
+
+    with qtbot.waitSignal(manager.device_closed) as blocker:
+        manager._on_device_closed(instance)
+
+    # Check signal emission
+    assert blocker.args == [instance]
+
+    # Check device removal
+    assert instance not in manager._active_devices
+    assert len(manager._active_devices) == 0
+
+
+def test_on_device_closed_nonexistent_device(subscribe_mock: MagicMock, qtbot) -> None:
+    """Test _on_device_closed method with a non-existent device."""
+    manager = ActiveDeviceManager()
+    instance = DeviceInstanceRef("nonexistent_type")
+
+    # Should not emit signal for non-existent device
+    with patch.object(manager, "device_closed") as signal_mock:
+        manager._on_device_closed(instance)
+        signal_mock.emit.assert_not_called()
+
+
+def test_disconnect_all_empty(
+    subscribe_mock: MagicMock, sendmsg_mock: MagicMock, qtbot
+) -> None:
+    """Test disconnect_all method with no active devices."""
+    manager = ActiveDeviceManager()
+    manager.disconnect_all()
+
+    sendmsg_mock.assert_not_called()
+
+
+def test_disconnect_all_with_devices(
+    active_devices_dict: dict[DeviceInstanceRef, ActiveDeviceProperties],
+    subscribe_mock: MagicMock,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test disconnect_all method with active devices."""
+    # Add another device for better testing
+    instance2 = DeviceInstanceRef("test_type_2")
+    device_props2 = ActiveDeviceProperties(
+        args=OpenDeviceArgs(instance2, "TestDevice2", frozendict()),
+        state=ConnectionStatus.CONNECTED,
+    )
+    active_devices_dict[instance2] = device_props2
+
+    manager = ActiveDeviceManager(active_devices_dict)
+    manager.disconnect_all()
+
+    # Should send close message for each device
+    assert sendmsg_mock.call_count == 2
+    for instance in active_devices_dict.keys():
+        sendmsg_mock.assert_any_call("device.close", instance=instance)
+
+
+@patch("frog.gui.hardware_set.device.show_error_message")
+def test_on_device_error(
+    show_error_mock: Mock,
+    subscribe_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test _on_device_error method."""
+    manager = ActiveDeviceManager()
+    instance = DeviceInstanceRef("test_type", "test_name")
+    error = Exception("Test error message")
+
+    manager._on_device_error(instance, error)
+
+    # Check error message display
+    show_error_mock.assert_called_once_with(
+        None,
+        f"A fatal error has occurred with the {instance!s} device: {error!s}",
+        title="Device error",
+    )
+
+
+def test_signal_connections(subscribe_mock: MagicMock, qtbot) -> None:
+    """Test that all Qt signals are properly defined."""
+    manager = ActiveDeviceManager()
+
+    # Check that signals exist and are Signal objects
+    assert hasattr(manager, "device_opened")
+    assert hasattr(manager, "device_started_open")
+    assert hasattr(manager, "device_closed")
+
+    # Signals should be accessible and of correct type
+    from PySide6.QtCore import Signal
+
+    assert isinstance(type(manager).device_opened, type(Signal()))
+    assert isinstance(type(manager).device_started_open, type(Signal()))
+    assert isinstance(type(manager).device_closed, type(Signal()))

--- a/tests/gui/hardware_set/test_device_control.py
+++ b/tests/gui/hardware_set/test_device_control.py
@@ -22,7 +22,7 @@ CONNECTED_DEVICES = (
 def widget(sendmsg_mock: MagicMock, subscribe_mock: Mock, qtbot) -> DeviceControl:
     """Return a DeviceControl fixture."""
     device_manager = MagicMock()
-    device_manager.get_connected_devices.return_value = CONNECTED_DEVICES
+    device_manager.connected_devices = CONNECTED_DEVICES
     return DeviceControl(device_manager)
 
 

--- a/tests/gui/hardware_set/test_device_control.py
+++ b/tests/gui/hardware_set/test_device_control.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from frog.device_info import DeviceBaseTypeInfo, DeviceInstanceRef, DeviceTypeInfo
-from frog.gui.hardware_set.device import ConnectionStatus, OpenDeviceArgs
+from frog.gui.hardware_set.device import (
+    ActiveDeviceProperties,
+    ConnectionStatus,
+    OpenDeviceArgs,
+)
 from frog.gui.hardware_set.device_view import DeviceControl
 
 CONNECTED_DEVICES = (
@@ -22,7 +26,10 @@ CONNECTED_DEVICES = (
 def widget(sendmsg_mock: MagicMock, subscribe_mock: Mock, qtbot) -> DeviceControl:
     """Return a DeviceControl fixture."""
     device_manager = MagicMock()
-    device_manager.connected_devices = CONNECTED_DEVICES
+    device_manager.devices = {
+        dev.instance: ActiveDeviceProperties(dev, ConnectionStatus.CONNECTED)
+        for dev in CONNECTED_DEVICES
+    }
     return DeviceControl(device_manager)
 
 

--- a/tests/gui/hardware_set/test_device_control.py
+++ b/tests/gui/hardware_set/test_device_control.py
@@ -21,14 +21,16 @@ CONNECTED_DEVICES = (
 @pytest.fixture
 def widget(sendmsg_mock: MagicMock, subscribe_mock: Mock, qtbot) -> DeviceControl:
     """Return a DeviceControl fixture."""
-    return DeviceControl(set(CONNECTED_DEVICES))
+    device_manager = MagicMock()
+    device_manager.get_connected_devices.return_value = CONNECTED_DEVICES
+    return DeviceControl(device_manager)
 
 
 def test_init(sendmsg_mock: MagicMock, subscribe_mock: MagicMock, qtbot) -> None:
     """Test the constructor."""
-    devices = MagicMock()
-    widget = DeviceControl(devices)
-    assert widget._connected_devices is devices
+    device_manager = MagicMock()
+    widget = DeviceControl(device_manager)
+    assert widget._device_manager is device_manager
 
     # Check that the list of devices was requested and the response is listened for
     subscribe_mock.assert_called_once_with(

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -120,68 +120,6 @@ def test_get_last_selected_hardware_set_no_cached(settings_mock: Mock, qtbot) ->
     settings_mock.value.assert_called_once_with("hardware_set/selected")
 
 
-@patch.object(HardwareSet, "load")
-@patch("frog.gui.hardware_set.hardware_sets_view.show_error_message")
-@patch("frog.gui.hardware_set.hardware_sets_view.QFileDialog.getOpenFileName")
-def test_import_hardware_set_success(
-    open_file_mock: Mock,
-    error_message_mock: Mock,
-    load_mock: Mock,
-    hw_control: HardwareSetsControl,
-    sendmsg_mock: MagicMock,
-    qtbot,
-) -> None:
-    """Test the _import_hardware_set() method when a file is loaded successfully."""
-    path = Path("dir/file.txt")
-    hw_set = MagicMock()
-    load_mock.return_value = hw_set
-    open_file_mock.return_value = (str(path), None)
-    hw_control._import_hardware_set()
-    load_mock.assert_called_once_with(path)
-    sendmsg_mock.assert_called_once_with("hardware_set.add", hw_set=hw_set)
-    error_message_mock.assert_not_called()
-
-
-@patch.object(HardwareSet, "load")
-@patch("frog.gui.hardware_set.hardware_sets_view.show_error_message")
-@patch("frog.gui.hardware_set.hardware_sets_view.QFileDialog.getOpenFileName")
-def test_import_hardware_set_cancelled(
-    open_file_mock: Mock,
-    error_message_mock: Mock,
-    load_mock: Mock,
-    hw_control: HardwareSetsControl,
-    sendmsg_mock: MagicMock,
-    qtbot,
-) -> None:
-    """Test the _import_hardware_set() method when the dialog is closed."""
-    open_file_mock.return_value = (None, None)
-    hw_control._import_hardware_set()
-    sendmsg_mock.assert_not_called()
-    error_message_mock.assert_not_called()
-    load_mock.assert_not_called()
-
-
-@patch.object(HardwareSet, "load")
-@patch("frog.gui.hardware_set.hardware_sets_view.show_error_message")
-@patch("frog.gui.hardware_set.hardware_sets_view.QFileDialog.getOpenFileName")
-def test_import_hardware_set_error(
-    open_file_mock: Mock,
-    error_message_mock: Mock,
-    load_mock: Mock,
-    hw_control: HardwareSetsControl,
-    sendmsg_mock: MagicMock,
-    qtbot,
-) -> None:
-    """Test the _import_hardware_set() method when a file fails to load."""
-    path = Path("dir/file.txt")
-    load_mock.side_effect = RuntimeError
-    open_file_mock.return_value = (str(path), None)
-    hw_control._import_hardware_set()
-    load_mock.assert_called_once_with(path)
-    sendmsg_mock.assert_not_called()
-    error_message_mock.assert_called_once()
-
-
 DEVICES = [
     OpenDeviceArgs.create(f"type{i}", f"class{i}", {"my_param": "my_value"})
     for i in range(2)

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -222,16 +222,14 @@ def test_connect_btn(
         )
 
 
-def test_disconnect_button(sendmsg_mock: Mock, qtbot) -> None:
+def test_disconnect_btn(sendmsg_mock: Mock, qtbot) -> None:
     """Test the disconnect button."""
     hw_control = HardwareSetsControl(ActiveDeviceManager(_dev_to_connected(DEVICES)))
-    with patch.object(hw_control, "_update_control_state") as update_mock:
-        hw_control._disconnect_btn.setEnabled(True)
-        hw_control._disconnect_btn.click()
-        sendmsg_mock.assert_has_calls(
-            [call("device.close", instance=d.instance) for d in DEVICES]
-        )
-        update_mock.assert_called_once_with()
+    hw_control._disconnect_btn.setEnabled(True)
+    hw_control._disconnect_btn.click()
+    sendmsg_mock.assert_has_calls(
+        [call("device.close", instance=d.instance) for d in DEVICES]
+    )
 
 
 def test_on_device_open_start(qtbot) -> None:

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -1,7 +1,6 @@
 """Tests for the HardwareSetsControl class."""
 
 from collections.abc import Iterable, Sequence
-from contextlib import nullcontext as does_not_raise
 from itertools import chain
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
@@ -9,12 +8,16 @@ from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 import pytest
 
 from frog.device_info import DeviceInstanceRef
-from frog.gui.hardware_set.device import ConnectionStatus, OpenDeviceArgs
+from frog.gui.hardware_set.device import (
+    ActiveDeviceManager,
+    ActiveDeviceProperties,
+    ConnectionStatus,
+    OpenDeviceArgs,
+)
 from frog.gui.hardware_set.hardware_set import (
     HardwareSet,
 )
 from frog.gui.hardware_set.hardware_sets_view import (
-    ActiveDeviceProperties,
     HardwareSetsControl,
     _get_last_selected_hardware_set,
 )
@@ -70,12 +73,12 @@ def test_init(
     update_mock: Mock,
     cur_hw_set_mock: PropertyMock,
     last_selected: str | None,
-    subscribe_mock: MagicMock,
     qtbot,
 ) -> None:
     """Test the constructor."""
     load_last_mock.return_value = last_selected
-    hw_sets = HardwareSetsControl()
+    device_manager = MagicMock()
+    hw_sets = HardwareSetsControl(device_manager)
     load_last_mock.assert_called_once_with()
     update_mock.assert_called_once_with()
     if last_selected:
@@ -83,9 +86,15 @@ def test_init(
     else:
         cur_hw_set_mock.assert_not_called()
 
-    # HardwareSetsComboBox's constructor will also call pub.subscribe
-    subscribe_mock.assert_any_call(hw_sets._on_device_open_end, "device.after_opening")
-    subscribe_mock.assert_any_call(hw_sets._on_device_closed, "device.closed")
+    device_manager.device_started_open.connect.assert_called_once_with(
+        hw_sets._on_device_open_start
+    )
+    device_manager.device_opened.connect.assert_called_once_with(
+        hw_sets._on_device_open_end
+    )
+    device_manager.device_closed.connect.assert_called_once_with(
+        hw_sets._on_device_closed
+    )
 
 
 @patch("frog.gui.hardware_set.hardware_sets_view.get_hardware_sets")
@@ -148,7 +157,7 @@ def test_update_control_state(
     connecting_devices: Sequence[int],
     connected_devices: Sequence[int],
     hardware_set: Sequence[int],
-    hw_control: HardwareSetsControl,
+    subscribe_mock: MagicMock,
     sendmsg_mock: MagicMock,
     qtbot,
 ) -> None:
@@ -157,9 +166,10 @@ def test_update_control_state(
     if connecting_devices:
         connect_enabled = False
 
-    hw_control._active_devices = _dev_to_connecting(
+    active_devices = _dev_to_connecting(
         _get_devices(connecting_devices)
     ) | _dev_to_connected(_get_devices(connected_devices))
+    hw_control = HardwareSetsControl(ActiveDeviceManager(active_devices))
 
     with patch(
         "frog.gui.hardware_set.hardware_sets_view"
@@ -188,112 +198,81 @@ def test_connect_btn(
     connected_devices: Sequence[int],
     hardware_set: Sequence[int],
     open_called: Sequence[int],
-    hw_control: HardwareSetsControl,
     qtbot,
 ) -> None:
     """Test the connect button."""
     file_path = Path("path/test.yaml")
+    active_devices = _dev_to_connected(_get_devices(connected_devices))
+    hw_control = HardwareSetsControl(ActiveDeviceManager(active_devices))
     with patch.object(hw_control, "_combo") as combo_mock:
         combo_mock.current_hardware_set_devices = _get_devices(hardware_set)
         combo_mock.current_hardware_set.file_path = file_path
-        with patch.object(
-            hw_control,
-            "_active_devices",
-            _dev_to_connected(_get_devices(connected_devices)),
-        ):
-            hw_control._connect_btn.click()
+        hw_control._connect_btn.click()
 
-            open_mock.assert_has_calls(
-                [
-                    call(dev.class_name, dev.instance, dev.params)
-                    for dev in _get_devices(open_called)
-                ],
-                any_order=True,
-            )
+        open_mock.assert_has_calls(
+            [
+                call(dev.class_name, dev.instance, dev.params)
+                for dev in _get_devices(open_called)
+            ],
+            any_order=True,
+        )
 
-            settings_mock.setValue.assert_called_once_with(
-                "hardware_set/selected", str(file_path)
-            )
+        settings_mock.setValue.assert_called_once_with(
+            "hardware_set/selected", str(file_path)
+        )
 
 
-def test_disconnect_button(
-    hw_control: HardwareSetsControl, sendmsg_mock: Mock, qtbot
-) -> None:
+def test_disconnect_button(sendmsg_mock: Mock, qtbot) -> None:
     """Test the disconnect button."""
+    hw_control = HardwareSetsControl(ActiveDeviceManager(_dev_to_connected(DEVICES)))
     with patch.object(hw_control, "_update_control_state") as update_mock:
-        with patch.object(hw_control, "_active_devices", _dev_to_connected(DEVICES)):
-            hw_control._disconnect_btn.setEnabled(True)
-            hw_control._disconnect_btn.click()
-            sendmsg_mock.assert_has_calls(
-                [call("device.close", instance=d.instance) for d in DEVICES]
-            )
-            update_mock.assert_called_once_with()
+        hw_control._disconnect_btn.setEnabled(True)
+        hw_control._disconnect_btn.click()
+        sendmsg_mock.assert_has_calls(
+            [call("device.close", instance=d.instance) for d in DEVICES]
+        )
+        update_mock.assert_called_once_with()
 
 
-def test_on_device_open_start(hw_control: HardwareSetsControl, qtbot) -> None:
+def test_on_device_open_start(qtbot) -> None:
     """Test the _on_device_open_start() method."""
-    device = DEVICES[0]
-    assert not hw_control._active_devices
-    hw_control._on_device_open_start(device.instance, device.class_name, device.params)
-    assert hw_control._active_devices == {
-        device.instance: ActiveDeviceProperties(device, ConnectionStatus.CONNECTING)
-    }
+    hw_control = HardwareSetsControl()
+    with patch.object(hw_control, "_update_control_state") as update_mock:
+        device = DEVICES[0]
+        hw_control._on_device_open_start(
+            device.instance, device.class_name, device.params
+        )
+        update_mock.assert_called_once_with()
 
 
 @patch("frog.gui.hardware_set.hardware_sets_view.settings")
-def test_on_device_open_end(
-    settings_mock: Mock, hw_control: HardwareSetsControl, qtbot
-) -> None:
+def test_on_device_open_end(settings_mock: Mock, qtbot) -> None:
     """Test the _on_device_open_end() method."""
     device = DEVICES[0]
-    assert not hw_control._active_devices
-    hw_control._active_devices[device.instance] = ActiveDeviceProperties(
-        device, ConnectionStatus.CONNECTING
-    )
+    active_devices = {
+        device.instance: ActiveDeviceProperties(device, ConnectionStatus.CONNECTING)
+    }
+    hw_control = HardwareSetsControl(ActiveDeviceManager(active_devices))
     with patch.object(hw_control, "_update_control_state") as update_mock:
         hw_control._on_device_open_end(
             instance=device.instance, class_name=device.class_name
         )
-        assert hw_control._active_devices == {
-            device.instance: ActiveDeviceProperties(device, ConnectionStatus.CONNECTED)
-        }
-        update_mock.assert_called_once_with()
         settings_mock.setValue.assert_has_calls(
             [
                 call(f"device/type/{device.instance!s}", device.class_name),
                 call(f"device/params/{device.class_name}", device.params),
             ]
         )
+        update_mock.assert_called_once_with()
 
 
 def test_on_device_closed(hw_control: HardwareSetsControl, qtbot) -> None:
     """Test the _on_device_closed() method."""
-    device = DEVICES[0]
-    assert not hw_control._active_devices
+    hw_control = HardwareSetsControl()
     with patch.object(hw_control, "_update_control_state") as update_mock:
-        hw_control._active_devices = {
-            device.instance: ActiveDeviceProperties(device, ConnectionStatus.CONNECTED)
-        }
+        device = DEVICES[0]
         hw_control._on_device_closed(device.instance)
-        assert not hw_control._active_devices
         update_mock.assert_called_once_with()
-
-
-def test_on_device_closed_not_found(hw_control: HardwareSetsControl, qtbot) -> None:
-    """Test that _on_device_closed() does not raise an error if device is not found."""
-    device = DEVICES[0]
-    assert not hw_control._active_devices
-    with does_not_raise():
-        hw_control._on_device_closed(device.instance)
-
-
-@patch("frog.gui.hardware_set.hardware_sets_view.show_error_message")
-def test_on_device_error(
-    error_message_mock: Mock, hw_control: HardwareSetsControl, qtbot
-) -> None:
-    """Test the _on_device_error() method."""
-    hw_control._on_device_error(DeviceInstanceRef("base_type"), RuntimeError("boo"))
-    error_message_mock.assert_called_once()
 
 
 def test_show_manage_devices_dialog(hw_control: HardwareSetsControl, qtbot) -> None:

--- a/tests/gui/hardware_set/test_menu.py
+++ b/tests/gui/hardware_set/test_menu.py
@@ -1,0 +1,79 @@
+"""Tests for the HardwareSetsMenu class."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from frog.gui.hardware_set.hardware_set import (
+    HardwareSet,
+)
+from frog.gui.hardware_set.menu import HardwareSetsMenu
+
+
+@pytest.fixture()
+def hw_menu(qtbot) -> HardwareSetsMenu:
+    """A fixture providing a HardwareSetsMenu."""
+    return HardwareSetsMenu()
+
+
+@patch.object(HardwareSet, "load")
+@patch("frog.gui.hardware_set.menu.show_error_message")
+@patch("frog.gui.hardware_set.menu.QFileDialog.getOpenFileName")
+def test_import_hardware_set_success(
+    open_file_mock: Mock,
+    error_message_mock: Mock,
+    load_mock: Mock,
+    hw_menu: HardwareSetsMenu,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the _import_hardware_set() method when a file is loaded successfully."""
+    path = Path("dir/file.txt")
+    hw_set = MagicMock()
+    load_mock.return_value = hw_set
+    open_file_mock.return_value = (str(path), None)
+    hw_menu._import_hardware_set()
+    load_mock.assert_called_once_with(path)
+    sendmsg_mock.assert_called_once_with("hardware_set.add", hw_set=hw_set)
+    error_message_mock.assert_not_called()
+
+
+@patch.object(HardwareSet, "load")
+@patch("frog.gui.hardware_set.menu.show_error_message")
+@patch("frog.gui.hardware_set.menu.QFileDialog.getOpenFileName")
+def test_import_hardware_set_cancelled(
+    open_file_mock: Mock,
+    error_message_mock: Mock,
+    load_mock: Mock,
+    hw_menu: HardwareSetsMenu,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the _import_hardware_set() method when the dialog is closed."""
+    open_file_mock.return_value = (None, None)
+    hw_menu._import_hardware_set()
+    sendmsg_mock.assert_not_called()
+    error_message_mock.assert_not_called()
+    load_mock.assert_not_called()
+
+
+@patch.object(HardwareSet, "load")
+@patch("frog.gui.hardware_set.menu.show_error_message")
+@patch("frog.gui.hardware_set.menu.QFileDialog.getOpenFileName")
+def test_import_hardware_set_error(
+    open_file_mock: Mock,
+    error_message_mock: Mock,
+    load_mock: Mock,
+    hw_menu: HardwareSetsMenu,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the _import_hardware_set() method when a file fails to load."""
+    path = Path("dir/file.txt")
+    load_mock.side_effect = RuntimeError
+    open_file_mock.return_value = (str(path), None)
+    hw_menu._import_hardware_set()
+    load_mock.assert_called_once_with(path)
+    sendmsg_mock.assert_not_called()
+    error_message_mock.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -279,6 +279,7 @@ dependencies = [
     { name = "pypubsub" },
     { name = "pyserial" },
     { name = "pyside6" },
+    { name = "python-slugify" },
     { name = "python-statemachine" },
     { name = "pyyaml" },
     { name = "schema" },
@@ -325,6 +326,7 @@ requires-dist = [
     { name = "pypubsub", specifier = ">=4.0.3,<5.0.0" },
     { name = "pyserial", specifier = ">=3.5,<4.0" },
     { name = "pyside6", specifier = ">=6.9.0,<7.0.0" },
+    { name = "python-slugify", specifier = ">=8.0.4" },
     { name = "python-statemachine", specifier = "~=2.3.6" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "schema", specifier = ">=0.7.7,<1.0.0" },
@@ -1251,6 +1253,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "python-statemachine"
 version = "2.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1384,6 +1398,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Adding the option to save new hardware sets is something that has been on my to-do list for a long time. I'd also like to add the option to export hardware sets (which would be handy for debugging issues @jonemurray may be having), but I felt like this PR was getting a bit long as it was anyway, so I'll leave that one for later.

It would be good to get your thoughts on the UX. The way I've implemented it now is to have a "Save" button in the `ManageDevicesDialog`, which saves the currently connected devices as a new hardware set and closes the dialog, but I think this is a little confusing. The point of the dialog is mostly just to let users manually connect to and disconnect from devices and the saving thing is extra functionality, but having a save button makes it look like you're _supposed_ to save it when you're done. If you have any better ideas, that would be appreciated! I suppose we could make it an option on the hardware sets menu instead.

I probably should have split this up (sorry!), but there are also some unrelated changes:

- Add a hardware sets menu, currently with just the option to import hardware sets, but we can add to it in future
- Add a close button to `ManageDevicesDialog` (requested by @jonemurray)
- Make a new `ActiveDeviceManager` object which is responsible for tracking changes to device states on the frontend

Without that last change, this would have been a lot harder. The current approach is to use pubsub events to monitor when devices are (dis)connected, but the problem is that it means multiple places in the frontend have to track what the current set of connected/connecting devices is. If a dialog which needs to know about device states is created after the program has started, then it also needs to be provided with a set of already-connected devices as it can't work this out from listening to the pubsub events alone. So now I've created an object to handle all this and the object can just be passed around by the parts of the code that care about device states. (Frankly, if I was starting the project now, I think I'd avoid pubsub altogether and just use Qt signals for everything, but I guess we're invested now!)

Closes #393.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [ ] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- **[x]** Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
